### PR TITLE
 Passing application-dependent parameters to queries

### DIFF
--- a/seep-common/src/main/java/uk/ac/imperial/lsds/seep/config/CommandLineArgs.java
+++ b/seep-common/src/main/java/uk/ac/imperial/lsds/seep/config/CommandLineArgs.java
@@ -1,13 +1,13 @@
 package uk.ac.imperial.lsds.seep.config;
 
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Properties;
-
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import uk.ac.imperial.lsds.seep.config.ConfigDef.Type;
+
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Properties;
 
 public class CommandLineArgs {
 
@@ -81,4 +81,13 @@ public class CommandLineArgs {
     	}
     	return value;
     }
+
+	/**
+	 * Gets the command line arguments that are for the query
+	 * (all the arguments that were not specified to the parser to accept)
+	 * @return array of query command line arguments
+	 */
+	public String[] getQueryArgs() {
+		return options.nonOptionArguments().toArray(new String[0]);
+	}
 }

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
@@ -58,6 +58,7 @@ public class Main {
 		// Get Properties with command line configuration 
 		List<ConfigKey> configKeys = MasterConfig.getAllConfigKey();
 		OptionParser parser = new OptionParser();
+		// Unrecognized options are passed through to the query
 		parser.allowsUnrecognizedOptions();
 		parser.accepts(MasterConfig.QUERY_FILE, "Jar file with the compiled SEEP query").withRequiredArg().required();
 		parser.accepts(MasterConfig.BASECLASS_NAME, "Name of the Base Class").withRequiredArg().required();

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
@@ -1,16 +1,8 @@
 package uk.ac.imperial.lsds.seepmaster;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.Executors;
-
 import joptsimple.OptionParser;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import uk.ac.imperial.lsds.seep.comm.Comm;
 import uk.ac.imperial.lsds.seep.comm.IOComm;
 import uk.ac.imperial.lsds.seep.comm.serialization.JavaSerializer;
@@ -26,12 +18,18 @@ import uk.ac.imperial.lsds.seepmaster.query.QueryManager;
 import uk.ac.imperial.lsds.seepmaster.ui.UI;
 import uk.ac.imperial.lsds.seepmaster.ui.UIFactory;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+
 
 public class Main {
 	
 	final private static Logger LOG = LoggerFactory.getLogger(Main.class);
 
-	private void executeMaster(String[] args, MasterConfig mc){
+	private void executeMaster(String[] args, MasterConfig mc, String[] queryArgs){
 		int infType = mc.getInt(MasterConfig.DEPLOYMENT_TARGET_TYPE);
 		LOG.info("Deploy target of type: {}", InfrastructureManagerFactory.nameInfrastructureManagerWithType(infType));
 		InfrastructureManager inf = InfrastructureManagerFactory.createInfrastructureManager(infType);
@@ -51,7 +49,7 @@ public class Main {
 		String queryPathFile = mc.getString(MasterConfig.QUERY_FILE);
 		String baseClass = mc.getString(MasterConfig.BASECLASS_NAME);
 		LOG.info("Loading query {} with baseClass: {} from file...", queryPathFile, baseClass);
-		qm.loadQueryFromFile(queryPathFile, baseClass);
+		qm.loadQueryFromFile(queryPathFile, baseClass, queryArgs);
 		LOG.info("Loading query...OK");
 		ui.start();		
 	}
@@ -60,6 +58,7 @@ public class Main {
 		// Get Properties with command line configuration 
 		List<ConfigKey> configKeys = MasterConfig.getAllConfigKey();
 		OptionParser parser = new OptionParser();
+		parser.allowsUnrecognizedOptions();
 		parser.accepts(MasterConfig.QUERY_FILE, "Jar file with the compiled SEEP query").withRequiredArg().required();
 		parser.accepts(MasterConfig.BASECLASS_NAME, "Name of the Base Class").withRequiredArg().required();
 		CommandLineArgs cla = new CommandLineArgs(args, parser, configKeys);
@@ -77,7 +76,7 @@ public class Main {
 		}
 		MasterConfig mc = new MasterConfig(validatedProperties);
 		Main instance = new Main();
-		instance.executeMaster(args, mc);
+		instance.executeMaster(args, mc, cla.getQueryArgs());
 	}
 	
 	private static boolean validateProperties(Properties validatedProperties){

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/query/QueryManager.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/query/QueryManager.java
@@ -220,11 +220,14 @@ public class QueryManager {
 		URLClassLoader ucl = new URLClassLoader(urls);
 		try {
 			baseI = ucl.loadClass(definitionClass);
-			// Use the default constructor if no arguments are given for backwards compatibility
-			if (queryArgs.length > 0) {
+			// For backwards compatibility, use the default constructor if one with a string array argument is not found
+			try {
 				baseInstance = baseI.getConstructor(String[].class).newInstance((Object)queryArgs);
-			} else {
+			} catch (NoSuchMethodException e)  {
 				baseInstance = baseI.newInstance();
+				if (queryArgs.length > 0) {
+					LOG.warn("Query arguments specified but Base class has no constructor taking a String[] argument");
+				}
 			}
 			// FIXME: eliminate hardcoded name
 			compose = baseI.getDeclaredMethod("compose", (Class<?>[])null);

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/query/QueryManager.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/query/QueryManager.java
@@ -1,32 +1,9 @@
 package uk.ac.imperial.lsds.seepmaster.query;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
+import com.esotericsoftware.kryo.Kryo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.esotericsoftware.kryo.Kryo;
-
-import uk.ac.imperial.lsds.seep.api.LogicalOperator;
-import uk.ac.imperial.lsds.seep.api.LogicalSeepQuery;
-import uk.ac.imperial.lsds.seep.api.Operator;
-import uk.ac.imperial.lsds.seep.api.PhysicalOperator;
-import uk.ac.imperial.lsds.seep.api.PhysicalSeepQuery;
-import uk.ac.imperial.lsds.seep.api.SeepQueryPhysicalOperator;
-import uk.ac.imperial.lsds.seep.api.UpstreamConnection;
+import uk.ac.imperial.lsds.seep.api.*;
 import uk.ac.imperial.lsds.seep.comm.Comm;
 import uk.ac.imperial.lsds.seep.comm.Connection;
 import uk.ac.imperial.lsds.seep.comm.protocol.MasterWorkerCommand;
@@ -36,6 +13,16 @@ import uk.ac.imperial.lsds.seep.infrastructure.EndPoint;
 import uk.ac.imperial.lsds.seep.util.Utils;
 import uk.ac.imperial.lsds.seepmaster.infrastructure.master.ExecutionUnit;
 import uk.ac.imperial.lsds.seepmaster.infrastructure.master.InfrastructureManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
+import java.util.Map.Entry;
 
 public class QueryManager {
 
@@ -93,10 +80,10 @@ public class QueryManager {
 		return inf.executionUnitsAvailable() >= executionUnitsRequiredToStart;
 	}
 	
-	public void loadQueryFromFile(String pathToJar, String definitionClass){
+	public void loadQueryFromFile(String pathToJar, String definitionClass, String[] queryArgs){
 		this.pathToQuery = pathToJar;
 		// get logical query
-		this.lsq = executeComposeFromQuery(pathToJar, definitionClass);
+		this.lsq = executeComposeFromQuery(pathToJar, definitionClass, queryArgs);
 		LOG.debug("Logical query loaded: {}", lsq.toString());
 		// get *all* classes required by that query and store their names
 		this.executionUnitsRequiredToStart = this.computeRequiredExecutionUnits(lsq);
@@ -215,7 +202,7 @@ public class QueryManager {
 		return lsq.getAllOperators().size();
 	}
 	
-	private LogicalSeepQuery executeComposeFromQuery(String pathToJar, String definitionClass){
+	private LogicalSeepQuery executeComposeFromQuery(String pathToJar, String definitionClass, String[] queryArgs){
 		Class<?> baseI = null;
 		Object baseInstance = null;
 		Method compose = null;
@@ -233,7 +220,12 @@ public class QueryManager {
 		URLClassLoader ucl = new URLClassLoader(urls);
 		try {
 			baseI = ucl.loadClass(definitionClass);
-			baseInstance = baseI.newInstance();
+			// Use the default constructor if no arguments are given for backwards compatibility
+			if (queryArgs.length > 0) {
+				baseInstance = baseI.getConstructor(String[].class).newInstance((Object)queryArgs);
+			} else {
+				baseInstance = baseI.newInstance();
+			}
 			// FIXME: eliminate hardcoded name
 			compose = baseI.getDeclaredMethod("compose", (Class<?>[])null);
 			lsq = (LogicalSeepQuery) compose.invoke(baseInstance, (Object[])null);


### PR DESCRIPTION
Issue: raulcf/SEEPng#15

* Allowing unrecognized options from the command line
* Pass these options to the Base class constructor so as not to change the QueryComposer interface and break existing queries
* When constructing the instance of the base class, the constructor that takes a string array as the only argument is used if it exists, otherwise the default constructor is used

USAGE:
To be able to pass parameters to queries:
* Create a constructor in the Base class with the following signature: `public Base(String[] args) {...}`
* `args` has the form of [option, value, option, value ...] which can be parsed by an option parser such as Jopt Simple
* Pass the query options to the master jar 

E.g. Addding option `--file.path /foo/bar` when running the master jar will pass `["file.path", "/foo/bar" ]` as `args` to Base 
 